### PR TITLE
Fixes #1 space characters in macros

### DIFF
--- a/lib/vim-mode-plus-macros.js
+++ b/lib/vim-mode-plus-macros.js
@@ -22,7 +22,8 @@ export default {
     this.subscriptions = new CompositeDisposable()
 
     const convertToCommand = (accumulator, character) => {
-      accumulator[`vim-mode-plus-macros:record-insert-of-${character}`] = () => this.typeCharacter(character)
+      const actualCharacter = character === 'space' ? ' ' : character
+      accumulator[`vim-mode-plus-macros:record-insert-of-${character}`] = () => this.typeCharacter(actualCharacter)
       return accumulator
     }
     const characterCommands = characters.reduce(convertToCommand, {})


### PR DESCRIPTION
The problem was that all the other characters are literal, except space, which isn't a valid identifier.

Added a special case